### PR TITLE
Add github actions for ci/cd

### DIFF
--- a/.github/workflows/export-data.yml
+++ b/.github/workflows/export-data.yml
@@ -1,4 +1,4 @@
-name: head-artifacts
+name: export-data
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -48,4 +48,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: yaml-version
-          path: ${CI_META_ARCHIVE_BASE}.tar.gz
+          path: clix-meta-data-*.tar.gz

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -44,7 +44,7 @@ jobs:
           cd ..
           zip -r ${CI_META_PREFIX}-devel.zip $CI_META_NAME
       - name: Upload artifacts
-        uses: actions/upload-artifacts@v2
+        uses: actions/upload-artifact@v2
         with:
           name: yaml-version
           path: cf-index-meta-data-*.*

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -39,14 +39,12 @@ jobs:
           cd $CI_META_DIR
           ci-meta-exporter ./master_table.xls
           cd ../..
-          export CI_META_ARCHIVE_BASE=${CI_META_PREFIX}-devel
-          echo "CI_META_ARCHIVE_BASE=$CI_META_ARCHIVE_BASE" >> $GITHUB_ENV
           echo "CI_META_NAME=$CI_META_NAME" >> $GITHUB_ENV
           echo "CI_META_DIR=$CI_META_DIR" >> $GITHUB_ENV
       - name: Upload normal line endings version
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.CI_META_ARCHIVE_BASE }}
+          name: ${{ env.CI_META_NAME }}
           path: artifact/*
       - name: Create windows line endings version
         run: |
@@ -56,5 +54,5 @@ jobs:
       - name: Upload windows line endings version
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.CI_META_ARCHIVE_BASE }}-win
+          name: ${{ env.CI_META_NAME }}-win
           path: artifact/*

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -21,12 +21,13 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-
-      # Runs a set of commands using the runners shell
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
       - name: Run a multi-line script
         run: |
-          conda env update -n ci-meta-exporter --file bitbucket-environment.yml
-          conda activate ci-meta-exporter
+          conda env update -n base --file bitbucket-environment.yml
           pip install -e ./python/
           export CI_META_PREFIX=cf-index-meta-data
           export CI_META_VERSION=$(ci-meta-exporter -v)

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -49,17 +49,29 @@ jobs:
           export CI_META_ARCHIVE_BASE=${CI_META_PREFIX}-devel
           echo "CI_META_ARCHIVE_BASE=$CI_META_ARCHIVE_BASE" >> $GITHUB_ENV
           echo "CI_META_NAME=$CI_META_NAME" >> $GITHUB_ENV
-      # - name: Create tarball
-      #   run: |
-      #     tar cvf ${CI_META_ARCHIVE_BASE}.tar.gz $CI_META_NAME
-      # - name: Create zip
-      #   run: |
-      #     cd $CI_META_NAME
-      #     $CONDA/bin/unix2dos README.md LICENSE.txt *.yml
-      #     cd ..
-      #     zip -r ${CI_META_ARCHIVE_BASE}.zip $CI_META_NAME
-      - name: Upload artifacts
+      - name: Upload normal line endings version
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.CI_META_ARCHIVE_BASE }}
+          name: ${{ env.CI_META_ARCHIVE_BASE }}-linux
+          path: ${{ env.CI_META_NAME }}
+      - name: Create windows line endings version
+        run: |
+          cd $CI_META_NAME
+          unix2dos README.md LICENSE.txt *.yml
+          cd ..
+      - name: Upload windows line endings version
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CI_META_ARCHIVE_BASE }}-win
+          path: ${{ env.CI_META_NAME }}
+      - name: Create mac line endings version
+        run: |
+          cd $CI_META_NAME
+          dos2unix README.md LICENSE.txt *.yml
+          unix2mac README.md LICENSE.txt *.yml
+          cd ..
+      - name: Upload mac line endings version
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CI_META_ARCHIVE_BASE }}-osx
           path: ${{ env.CI_META_NAME }}

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -40,6 +40,6 @@ jobs:
           cd ..
           tar cvf ${CI_META_PREFIX}-devel.tar.gz $CI_META_NAME
           cd $CI_META_NAME
-          unix2dos README.md LICENSE.txt *.yml
+          $CONDA/bin/unix2dos README.md LICENSE.txt *.yml
           cd ..
           zip -r ${CI_META_PREFIX}-devel.zip $CI_META_NAME

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -33,26 +33,28 @@ jobs:
           export CI_META_PREFIX=clix-meta-data
           export CI_META_VERSION=$(ci-meta-exporter -v)
           export CI_META_NAME=${CI_META_PREFIX}-${CI_META_VERSION}
-          mkdir $CI_META_NAME
-          cp master_table.xls README.md LICENSE.txt $CI_META_NAME/
-          cd $CI_META_NAME
+          export CI_META_DIR=artifact/$CI_META_NAME
+          mkdir -p $CI_META_DIR
+          cp master_table.xls README.md LICENSE.txt $CI_META_DIR/
+          cd $CI_META_DIR
           ci-meta-exporter ./master_table.xls
-          cd ..
+          cd ../..
           export CI_META_ARCHIVE_BASE=${CI_META_PREFIX}-devel
           echo "CI_META_ARCHIVE_BASE=$CI_META_ARCHIVE_BASE" >> $GITHUB_ENV
           echo "CI_META_NAME=$CI_META_NAME" >> $GITHUB_ENV
+          echo "CI_META_DIR=$CI_META_DIR" >> $GITHUB_ENV
       - name: Upload normal line endings version
         uses: actions/upload-artifact@v2
         with:
           name: ${{ env.CI_META_ARCHIVE_BASE }}
-          path: ${{ env.CI_META_NAME }}
+          path: artifact/*
       - name: Create windows line endings version
         run: |
-          cd $CI_META_NAME
+          cd $CI_META_DIR
           unix2dos README.md LICENSE.txt *.yml
-          cd ..
+          cd ../..
       - name: Upload windows line endings version
         uses: actions/upload-artifact@v2
         with:
           name: ${{ env.CI_META_ARCHIVE_BASE }}-win
-          path: ${{ env.CI_META_NAME }}
+          path: artifact/*

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -43,3 +43,8 @@ jobs:
           $CONDA/bin/unix2dos README.md LICENSE.txt *.yml
           cd ..
           zip -r ${CI_META_PREFIX}-devel.zip $CI_META_NAME
+      - name: Upload artifacts
+        uses: actions/upload-artifacts@v2
+        with:
+          name: yaml-version
+          path: cf-index-meta-data-*.*

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           conda env update -n base --file bitbucket-environment.yml
           pip install -e ./python/
-          export CI_META_PREFIX=cf-index-meta-data
+          export CI_META_PREFIX=clix-meta-data
           export CI_META_VERSION=$(ci-meta-exporter -v)
           echo 'devel' >ci-meta-version.txt
           export CI_META_NAME=${CI_META_PREFIX}-${CI_META_VERSION}
@@ -38,13 +38,14 @@ jobs:
           cd $CI_META_NAME
           ci-meta-exporter ./master_table.xls
           cd ..
-          tar cvf ${CI_META_PREFIX}-devel.tar.gz $CI_META_NAME
+          export CI_META_ARCHIVE_BASE=${CI_META_PREFIX}-devel
+          tar cvf ${CI_META_ARCHIVE_BASE}.tar.gz $CI_META_NAME
           cd $CI_META_NAME
           $CONDA/bin/unix2dos README.md LICENSE.txt *.yml
           cd ..
-          zip -r ${CI_META_PREFIX}-devel.zip $CI_META_NAME
+          zip -r ${CI_META_ARCHIVE_BASE}.zip $CI_META_NAME
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: yaml-version
-          path: cf-index-meta-data-*.*
+          path: ${CI_META_ARCHIVE_BASE}.tar.gz

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -25,27 +25,39 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Run a multi-line script
+      - name: Add conda to system path
         run: |
-          conda env update -n base --file bitbucket-environment.yml
+          # $CONDA is an env variable pointing to the root of the miniconda directory
+          echo $CONDA/bin >> $GITHUB_PATH
+      - name: Install dependencies
+        run: |
+          conda env update --file environment.yml --name base
+      - name: Install exporter
+        run: |
           pip install -e ./python/
+      - name: Prepare versioned directory
+        run: |
           export CI_META_PREFIX=clix-meta-data
           export CI_META_VERSION=$(ci-meta-exporter -v)
           echo 'devel' >ci-meta-version.txt
           export CI_META_NAME=${CI_META_PREFIX}-${CI_META_VERSION}
           mkdir $CI_META_NAME
-          cp master_table.xls README.md LICENSE.txt $CI_META_NAME
+          cp master_table.xls README.md LICENSE.txt $CI_META_NAME/
           cd $CI_META_NAME
           ci-meta-exporter ./master_table.xls
           cd ..
           export CI_META_ARCHIVE_BASE=${CI_META_PREFIX}-devel
-          tar cvf ${CI_META_ARCHIVE_BASE}.tar.gz $CI_META_NAME
-          cd $CI_META_NAME
-          $CONDA/bin/unix2dos README.md LICENSE.txt *.yml
-          cd ..
-          zip -r ${CI_META_ARCHIVE_BASE}.zip $CI_META_NAME
+      # - name: Create tarball
+      #   run: |
+      #     tar cvf ${CI_META_ARCHIVE_BASE}.tar.gz $CI_META_NAME
+      # - name: Create zip
+      #   run: |
+      #     cd $CI_META_NAME
+      #     $CONDA/bin/unix2dos README.md LICENSE.txt *.yml
+      #     cd ..
+      #     zip -r ${CI_META_ARCHIVE_BASE}.zip $CI_META_NAME
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: yaml-version
-          path: clix-meta-data-*.tar.gz
+          name: ${{ env.CI_META_ARCHIVE_BASE }}
+          path: ${{ env.CI_META_NAME }}

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: head-artifacts
 
 # Controls when the action will run. Triggers the workflow on push or pull request
@@ -10,16 +8,11 @@ on:
   pull_request:
     branches: [ master ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -39,7 +32,6 @@ jobs:
         run: |
           export CI_META_PREFIX=clix-meta-data
           export CI_META_VERSION=$(ci-meta-exporter -v)
-          echo 'devel' >ci-meta-version.txt
           export CI_META_NAME=${CI_META_PREFIX}-${CI_META_VERSION}
           mkdir $CI_META_NAME
           cp master_table.xls README.md LICENSE.txt $CI_META_NAME/
@@ -52,7 +44,7 @@ jobs:
       - name: Upload normal line endings version
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.CI_META_ARCHIVE_BASE }}-linux
+          name: ${{ env.CI_META_ARCHIVE_BASE }}
           path: ${{ env.CI_META_NAME }}
       - name: Create windows line endings version
         run: |
@@ -63,15 +55,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ env.CI_META_ARCHIVE_BASE }}-win
-          path: ${{ env.CI_META_NAME }}
-      - name: Create mac line endings version
-        run: |
-          cd $CI_META_NAME
-          dos2unix README.md LICENSE.txt *.yml
-          unix2mac README.md LICENSE.txt *.yml
-          cd ..
-      - name: Upload mac line endings version
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.CI_META_ARCHIVE_BASE }}-osx
           path: ${{ env.CI_META_NAME }}

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -1,0 +1,44 @@
+# This is a basic workflow to help you get started with Actions
+
+name: head-artifacts
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          conda env update -n ci-meta-exporter --file bitbucket-environment.yml
+          conda activate ci-meta-exporter
+          pip install -e ./python/
+          export CI_META_PREFIX=cf-index-meta-data
+          export CI_META_VERSION=$(ci-meta-exporter -v)
+          echo 'devel' >ci-meta-version.txt
+          export CI_META_NAME=${CI_META_PREFIX}-${CI_META_VERSION}
+          mkdir $CI_META_NAME
+          cp master_table.xls README.md LICENSE.txt $CI_META_NAME
+          cd $CI_META_NAME
+          ci-meta-exporter ./master_table.xls
+          cd ..
+          tar cvf ${CI_META_PREFIX}-devel.tar.gz $CI_META_NAME
+          cd $CI_META_NAME
+          unix2dos README.md LICENSE.txt *.yml
+          cd ..
+          zip -r ${CI_META_PREFIX}-devel.zip $CI_META_NAME

--- a/.github/workflows/head.yml
+++ b/.github/workflows/head.yml
@@ -47,6 +47,8 @@ jobs:
           ci-meta-exporter ./master_table.xls
           cd ..
           export CI_META_ARCHIVE_BASE=${CI_META_PREFIX}-devel
+          echo "CI_META_ARCHIVE_BASE=$CI_META_ARCHIVE_BASE" >> $GITHUB_ENV
+          echo "CI_META_NAME=$CI_META_NAME" >> $GITHUB_ENV
       # - name: Create tarball
       #   run: |
       #     tar cvf ${CI_META_ARCHIVE_BASE}.tar.gz $CI_META_NAME

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: ci-meta-exporter
+
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - python
+  - dos2unix
+  - zip


### PR DESCRIPTION
This adds a github actions workflow for ci. That means that in pull requests, yaml files are created and made available for inspection as artifacts on the workflow. This lays the foundation for a release workflow that allows for easy download of released versions of the metadata in yaml form.