### PR TITLE
ci: Add pre-release github action

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,66 @@
+---
+name: "pre-release"
+
+on:
+  push:
+    branches:
+      - "master"
+    tags-ignore:
+      - "*"
+
+jobs:
+  gh_pre_release:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout source code"
+        uses: "actions/checkout@v2"
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Add conda to system path
+        run: |
+          # $CONDA is an env variable pointing to the root of the miniconda directory
+          echo $CONDA/bin >> $GITHUB_PATH
+      - name: Install dependencies
+        run: |
+          conda env update --file environment.yml --name base
+      - name: Install exporter
+        run: |
+          pip install -e ./python/
+      - name: Prepare versioned directory
+        run: |
+          export CI_META_PREFIX=clix-meta-data
+          export CI_META_VERSION=$(ci-meta-exporter -v)
+          export CI_META_NAME=${CI_META_PREFIX}-${CI_META_VERSION}
+          export CI_META_DIR=artifact/$CI_META_NAME
+          mkdir -p $CI_META_DIR
+          cp master_table.xls README.md LICENSE.txt $CI_META_DIR/
+          cd $CI_META_DIR
+          ci-meta-exporter ./master_table.xls
+          cd ..
+          echo "CI_META_NAME=$CI_META_NAME" >> $GITHUB_ENV
+          echo "CI_META_DIR=$CI_META_DIR" >> $GITHUB_ENV
+      - name: Prepare tarball
+        run: |
+          tar cvf ${CI_META_NAME}.tar.gz ${CI_META_NAME}
+      - name: Create windows line endings version
+        run: |
+          cd $CI_META_NAME
+          unix2dos README.md LICENSE.txt *.yml
+          cd ..
+      - name: Prepare zipfile
+        run: |
+          zip -r {CI_META_NAME}.zip ${CI_META_NAME}
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            artifact/${CI_META_NAME}.tar.gz
+            artifact/${CI_META_NAME}.zip
+        id: "automatic_releases"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -29,12 +29,13 @@ jobs:
       - name: Install exporter
         run: |
           pip install -e ./python/
-      - name: Prepare versioned directory
+      - name: Prepare data
+        id: preparation
         run: |
           export CI_META_PREFIX=clix-meta-data
           export CI_META_VERSION=$(ci-meta-exporter -v)
           export CI_META_NAME=${CI_META_PREFIX}-${CI_META_VERSION}
-          echo "CI_META_NAME=$CI_META_NAME" >> $GITHUB_ENV
+          echo "::set-output name=ci-meta-name::${CI_META_NAME}"
           mkdir $CI_META_NAME
           cp master_table.xls README.md LICENSE.txt $CI_META_NAME/
           cd $CI_META_NAME
@@ -53,6 +54,6 @@ jobs:
           prerelease: true
           title: "Development Build"
           files: |
-            *.tar.gz
-            *.zip
+            ${{ steps.preparation.outputs.ci-meta-name }}.tar.gz
+            ${{ steps.preparation.outputs.ci-meta-name }}.zip
         id: "automatic_releases"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -34,24 +34,16 @@ jobs:
           export CI_META_PREFIX=clix-meta-data
           export CI_META_VERSION=$(ci-meta-exporter -v)
           export CI_META_NAME=${CI_META_PREFIX}-${CI_META_VERSION}
-          export CI_META_DIR=artifact/$CI_META_NAME
-          mkdir -p $CI_META_DIR
-          cp master_table.xls README.md LICENSE.txt $CI_META_DIR/
-          cd $CI_META_DIR
+          echo "CI_META_NAME=$CI_META_NAME" >> $GITHUB_ENV
+          mkdir $CI_META_NAME
+          cp master_table.xls README.md LICENSE.txt $CI_META_NAME/
+          cd $CI_META_NAME
           ci-meta-exporter ./master_table.xls
           cd ..
-          echo "CI_META_NAME=$CI_META_NAME" >> $GITHUB_ENV
-          echo "CI_META_DIR=$CI_META_DIR" >> $GITHUB_ENV
-      - name: Prepare tarball
-        run: |
           tar cvf ${CI_META_NAME}.tar.gz ${CI_META_NAME}
-      - name: Create windows line endings version
-        run: |
           cd $CI_META_NAME
           unix2dos README.md LICENSE.txt *.yml
           cd ..
-      - name: Prepare zipfile
-        run: |
           zip -r {CI_META_NAME}.zip ${CI_META_NAME}
 
       - uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -53,6 +53,6 @@ jobs:
           prerelease: true
           title: "Development Build"
           files: |
-            artifact/${CI_META_NAME}.tar.gz
-            artifact/${CI_META_NAME}.zip
+            ${CI_META_NAME}.tar.gz
+            ${CI_META_NAME}.zip
         id: "automatic_releases"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -53,6 +53,6 @@ jobs:
           prerelease: true
           title: "Development Build"
           files: |
-            ${CI_META_NAME}.tar.gz
-            ${CI_META_NAME}.zip
+            *.tar.gz
+            *.zip
         id: "automatic_releases"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -44,7 +44,7 @@ jobs:
           cd $CI_META_NAME
           unix2dos README.md LICENSE.txt *.yml
           cd ..
-          zip -r {CI_META_NAME}.zip ${CI_META_NAME}
+          zip -r ${CI_META_NAME}.zip ${CI_META_NAME}
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:


### PR DESCRIPTION
This adds a github action workflow for the automatic generation of a pre-release from the latest head.

closes #35 