### PR TITLE
ci: Add tagged-release github action workflow

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,0 +1,57 @@
+---
+name: "tagged-release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  gh_pre_release:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout source code"
+        uses: "actions/checkout@v2"
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Add conda to system path
+        run: |
+          # $CONDA is an env variable pointing to the root of the miniconda directory
+          echo $CONDA/bin >> $GITHUB_PATH
+      - name: Install dependencies
+        run: |
+          conda env update --file environment.yml --name base
+      - name: Install exporter
+        run: |
+          pip install -e ./python/
+      - name: Prepare data
+        id: preparation
+        run: |
+          export CI_META_PREFIX=clix-meta-data
+          export CI_META_VERSION=$(ci-meta-exporter -v)
+          export CI_META_NAME=${CI_META_PREFIX}-${CI_META_VERSION}
+          echo "::set-output name=ci-meta-name::${CI_META_NAME}"
+          mkdir $CI_META_NAME
+          cp master_table.xls README.md LICENSE.txt $CI_META_NAME/
+          cd $CI_META_NAME
+          ci-meta-exporter ./master_table.xls
+          cd ..
+          tar cvf ${CI_META_NAME}.tar.gz ${CI_META_NAME}
+          cd $CI_META_NAME
+          unix2dos README.md LICENSE.txt *.yml
+          cd ..
+          zip -r ${CI_META_NAME}.zip ${CI_META_NAME}
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            ${{ steps.preparation.outputs.ci-meta-name }}.tar.gz
+            ${{ steps.preparation.outputs.ci-meta-name }}.zip
+        id: "automatic_releases"


### PR DESCRIPTION
This adds a basic workflow for the release of normal versions.

Closes #39 