### PR TITLE
ci: Change master to main in github workflows

### DIFF
--- a/.github/workflows/export-data.yml
+++ b/.github/workflows/export-data.yml
@@ -1,12 +1,12 @@
 name: export-data
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# events but only for the main branch
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -4,7 +4,7 @@ name: "pre-release"
 on:
   push:
     branches:
-      - "master"
+      - "main"
     tags-ignore:
       - "*"
 


### PR DESCRIPTION
When we renamed the principal branch from master to main, we didn't change the github workflow files accordingly. This PR fixes that. As a consequence, the `latest` pre-releases should re-appear.