### PR TITLE
feat: Quote non-numeric values for data entry of quantity parameters

### DIFF
--- a/python/ci_meta/exporter/mastertable.py
+++ b/python/ci_meta/exporter/mastertable.py
@@ -78,11 +78,17 @@ def tr_parameter(parameter):
              'kind': 'reducer',
              'reducer': parameter['reducer']}
     elif parameter['value'] is not None:
+        raw_value = parameter['value']
+        try:
+            float(raw_value)
+            value = raw_value
+        except ValueError:
+            value = f'"{raw_value}"'
         d = {'var_name': parameter['name'],
              'kind': 'quantity',
              'standard_name': parameter['standard_name'],
              'proposed_standard_name': parameter['proposed_standard_name'],
-             'data': parameter['value'],
+             'data': value,
              'units': parameter['units'],
              'long_name': parameter['long_name']}
     else:


### PR DESCRIPTION
Closes #31 

This adds quotation to non-numeric values of the data entry in parameters of quantity kind. In particular, this makes templated parameters of the form "{TT}" more easily digestable.