### PR TITLE
fix: Fix comparison operator order (fixes #72)

### DIFF
--- a/python/ci_meta/exporter/mastertable.py
+++ b/python/ci_meta/exporter/mastertable.py
@@ -6,11 +6,13 @@ import regex as re
 import pyexcel as pe
 
 
+# Order matters! Earlier operators will be preferred,
+# so <= MUST appear before <, etc.
 SUPPORTED_OPERATORS = [
-    '<',
-    '>',
     '<=',
     '>=',
+    '<',
+    '>',
 ]
 SUPPORTED_REDUCERS = [
     'min',


### PR DESCRIPTION
Up to version 0.4.0, there is a bug in the python exporter that converts all >=  and <= operators into > and <, respectively.
This PR fixes that so that the correct comparison operators are output.