### PR TITLE
feat: Updated templates: version is now a "document" in yaml files (closes #75)

### DIFF
--- a/python/ci_meta/exporter/templates/index_definitions.yml
+++ b/python/ci_meta/exporter/templates/index_definitions.yml
@@ -1,7 +1,8 @@
 # These index definitions are auto-generated from the master table at
 # https://github.com/clix-meta/clix-meta
-
-# This is based on version {{ version }}.
+---
+clix_meta_version: {{ version }}
+...
 ---
 indices:
 {% for idx in indices %}

--- a/python/ci_meta/exporter/templates/variables.yml
+++ b/python/ci_meta/exporter/templates/variables.yml
@@ -1,7 +1,8 @@
 # These variables are auto-generated from the master table at
 # https://github.com/clix-meta/clix-meta
-
-# This is based on version {{ version }}.
+---
+clix_meta_version: {{ version }}
+...
 ---
 variables:
 {% for var in variables %}


### PR DESCRIPTION
Python readers should now use `yaml.safe_load_all`