### PR TITLE
Enable parsing reference period parameter

### DIFF
--- a/python/ci_meta/exporter/mastertable.py
+++ b/python/ci_meta/exporter/mastertable.py
@@ -93,6 +93,12 @@ def tr_parameter(parameter):
              'data': value,
              'units': parameter['units'],
              'long_name': parameter['long_name']}
+    elif parameter["time_range"] is not None:
+        d = {
+            "var_name": parameter["name"],
+            "kind": "time_range",
+            "data": parameter["time_range"],
+        }
     else:
         raise RuntimeError(f"Invalid parameter found {parameter[0]}")
     return d
@@ -109,8 +115,13 @@ def split_parameter_definitions(parameter_definitions_string, parameter_names):
         r'value: (?P<value>[^,]*), '
         r'unit: (?P<units>[^,)]*)(, |\))'
         r'(long_name: \p{Pi}(?P<long_name>[^\p{Pf}]*)\p{Pf}\))?')
-    param_regex = r'{}: (?:{}|{}|{})'.format(
-        name_regex, red_regex, op_regex, qty_regex
+    timestamp_regex = (
+        r"[1-9][0-9]*(-[0-1][0-9](-[0-3][0-9](T[0-1][0-9][0-1][0-9][0-6][0-9])?)?)?"
+    )
+    period_regex = r"P[0-9]*Y([0-9]*M([0-9]*D)?)?"
+    time_range_regex = rf"(?P<time_range>{timestamp_regex}/{timestamp_regex}|{timestamp_regex}/{period_regex}|{period_regex}/{timestamp_regex})"
+    param_regex = r"{}: (?:{}|{}|{}|{})".format(
+        name_regex, red_regex, op_regex, qty_regex, time_range_regex
     )
     matcher = re.compile(param_regex)
     result = [tr_parameter(p)

--- a/python/ci_meta/exporter/mastertable.py
+++ b/python/ci_meta/exporter/mastertable.py
@@ -116,7 +116,7 @@ def split_parameter_definitions(parameter_definitions_string, parameter_names):
         r'unit: (?P<units>[^,)]*)(, |\))'
         r'(long_name: \p{Pi}(?P<long_name>[^\p{Pf}]*)\p{Pf}\))?')
     timestamp_regex = (
-        r"[1-9][0-9]*(-[0-1][0-9](-[0-3][0-9](T[0-1][0-9][0-1][0-9][0-6][0-9])?)?)?"
+        r"[1-9][0-9]*(-[0-1][0-9](-[0-3][0-9](T[0-2][0-9][0-5][0-9][0-5][0-9])?)?)?"
     )
     period_regex = r"P[0-9]*Y([0-9]*M([0-9]*D)?)?"
     time_range_regex = rf"(?P<time_range>{timestamp_regex}/{timestamp_regex}|{timestamp_regex}/{period_regex}|{period_regex}/{timestamp_regex})"

--- a/python/ci_meta/exporter/templates/index_definitions.yml
+++ b/python/ci_meta/exporter/templates/index_definitions.yml
@@ -44,6 +44,8 @@ indices:
           operator: {{- param.operator|add_space(quote=True) }}
 {% elif param.kind == 'reducer' %}
           reducer: {{- param.reducer|add_space }}
+{% elif param.kind == 'time_range' %}
+          data: {{- param.data|add_space }}
 {% else %}
           # Warning: Unknown kind!
 {% endif %}


### PR DESCRIPTION
Adds a mechanism to identify and parse the reference period. Valid formats are two (partial or full) ISO timestamps e.g. `1961-01-01T230000` separated by `/`, or a timestamp and a period specification e.g. `P30Y5M`.
Examples
- `1961/1990`
- `1961/1990-05-25`
- `1961/P30Y`

Note that this is currently not checking if timestamps are valid, e.g. `1961-19-38`, as this is likely better to do against possible input data.

Also not sure which issues this is related to, so maybe someone could add these here for reference.