### PR TITLE
feat: Move version information to yaml proper

### DIFF
--- a/python/ci_meta/exporter/templates/index_definitions.yml
+++ b/python/ci_meta/exporter/templates/index_definitions.yml
@@ -1,8 +1,9 @@
 # These index definitions are auto-generated from the master table at
 # https://github.com/clix-meta/clix-meta
-
-# This is based on version {{ version }}.
 ---
+distribution:
+  name: clix-meta
+  version: {{ version }}
 indices:
 {% for idx in indices %}
   {{ idx.var_name }}:

--- a/python/ci_meta/exporter/templates/variables.yml
+++ b/python/ci_meta/exporter/templates/variables.yml
@@ -1,8 +1,9 @@
 # These variables are auto-generated from the master table at
 # https://github.com/clix-meta/clix-meta
-
-# This is based on version {{ version }}.
 ---
+distribution:
+  name: clix-meta
+  version: {{ version }}
 variables:
 {% for var in variables %}
   {{ var.var_name }}:


### PR DESCRIPTION
Closes #75, supersedes #78.

This moves the clix-meta version information into the yaml proper.